### PR TITLE
Fixed cargo counting towards hatches

### DIFF
--- a/app/views/MatchBreakdown2019.js
+++ b/app/views/MatchBreakdown2019.js
@@ -52,7 +52,7 @@ export default class MatchBreakdown2019 extends React.Component {
         panelCount++
       }
       if (breakdown["bay" + i].includes("Cargo")) {
-        panelCount++
+        cargoCount++
       }
     }
     return `${panelCount} / ${cargoCount}`


### PR DESCRIPTION
This fixes a bug where both the cargo and panels were being counted towards the number of panels for each cargo ship in the 2019 match breakdown.

This fixes #15.